### PR TITLE
Mark remaining tests that assume an implementation of big integers as optional

### DIFF
--- a/TestSuite/IntegerTest.som
+++ b/TestSuite/IntegerTest.som
@@ -113,26 +113,32 @@ IntegerTest = TestCase (
     self assert: 42 equals: '42' asInteger.
     self assert: -2 equals: '-2' asInteger.
   )
-  
+
   testIntegerLiterals = (
     "Make sure the parser reads literals correctly. So, check some basic properties"
-    self assert: 2 / 2                                     equals:                       1.
-    self assert: 50 + 50                                   equals:                     100.
-    self assert: 92233720368 * 100000000 + 54775807        equals:     9223372036854775807.
-    self assert: 92233720368 * 100000000 + 54775807 * 100  equals:   922337203685477580700.
-    self assert: 50 - 100                                  equals:                     -50.
-    self assert: 21474 * -100000 - 83648                   equals:             -2147483648.
-    self assert: 92233720368 * 100000000 + 54775807 * -100 equals:  -922337203685477580700.
+    self assert:                      1 equals:  2 / 2.
+    self assert:                    100 equals:  50 + 50.
+    self assert:    9223372036854775807 equals:  92233720368 * 100000000 + 54775807.
+    self assert:                    -50 equals:  50 - 100.
+    self assert:            -2147483648 equals:  21474 * -100000 - 83648.
+
+    self optional: #bigInteger
+         assert:  922337203685477580700 equals:  92233720368 * 100000000 + 54775807 * 100.
+    self optional: #bigInteger
+         assert: -922337203685477580700 equals:  92233720368 * 100000000 + 54775807 * -100.
   )
-  
+
   testFromString = (
     self assert:                      1 equals: (Integer fromString:                      '1').
     self assert:                    100 equals: (Integer fromString:                    '100').
     self assert:    9223372036854775807 equals: (Integer fromString:    '9223372036854775807').
-    self assert:  922337203685477580700 equals: (Integer fromString:  '922337203685477580700').
     self assert:                    -50 equals: (Integer fromString:                    '-50').
     self assert:            -2147483648 equals: (Integer fromString:            '-2147483648').
-    self assert: -922337203685477580700 equals: (Integer fromString: '-922337203685477580700').
+
+    self optional: #bigInteger
+         assert:  922337203685477580700 equals: (Integer fromString:  '922337203685477580700').
+    self optional: #bigInteger
+         assert: -922337203685477580700 equals: (Integer fromString: '-922337203685477580700').
   )
 
   testRangeBorders = (
@@ -255,13 +261,13 @@ IntegerTest = TestCase (
 
     self assert:                               0 equals: ( 0 raisedTo:   5).
     self assert:                               1 equals: ( 0 raisedTo:   0).
-    
+
     "Negative exponents are not yet supported"
     self assert:                               1 equals: ( 0 raisedTo:  -1).
     self assert:                               1 equals: ( 0 raisedTo:  -2).
     self assert:                               1 equals: (10 raisedTo:  -1).
     self assert:                               1 equals: (10 raisedTo:  -2).
-    
+
     "Double exponents are not yet supported"
     self assert:                               2 equals: ( 2 raisedTo:  1.5).
     self assert:                               4 equals: ( 2 raisedTo:  2.4).
@@ -324,30 +330,48 @@ IntegerTest = TestCase (
     "We need to test numbers that are 64bit or less, larger than 64bit,
      positive, and negative"
     | big small |
-    big   := #(1 100 9223372036854775807 922337203685477580700
-               -50 -2147483648 922337203685477580700 -922337203685477580700
-               922337203685477580700).
-    small := #(0  52 9223372036854775296 922337203685477529600
-               -51 -2147483650                     1 -922337203685477580701
-               -922337203685477580701).
+    big   := #(1 100 9223372036854775807 -50 -2147483648).
+    small := #(0  52 9223372036854775296 -51 -2147483650).
 
     big doIndexes: [:i |
       self assert: (small at: i)  equals: ((big   at: i) min: (small at: i)).
-      self assert: (small at: i)  equals: ((small at: i) min: (big   at: i)) ]
+      self assert: (small at: i)  equals: ((small at: i) min: (big   at: i)) ].
+
+    "not sure whether we should really insist on this"
+    big   := #( 922337203685477580700  922337203685477580700
+               -922337203685477580700  922337203685477580700).
+    small := #( 922337203685477529600                      1
+               -922337203685477580701 -922337203685477580701).
+    big doIndexes: [:i |
+      self optional: #toBeSpecified
+           assert: (small at: i)  equals: ((big   at: i) min: (small at: i)).
+      self optional: #toBeSpecified
+           assert: (small at: i)  equals: ((small at: i) min: (big   at: i)) ].
   )
 
   testMax = (
     "We need to test numbers that are 64bit or less, larger than 64bit,
      positive, and negative"
     | big small |
-    big   := #(1 100 9223372036854775807 922337203685477580700
-               -50 -2147483648 922337203685477580700 -922337203685477580700
-               922337203685477580700).
-    small := #(0  52 9223372036854775296 922337203685477529600
-               -51 -2147483650                     1 -922337203685477580701
-               -922337203685477580701).
+    big   := #(1 100 9223372036854775807 -50 -2147483648).
+    small := #(0  52 9223372036854775296 -51 -2147483650).
     big doIndexes: [:i |
       self assert: (big at: i)  equals: ((big   at: i) max: (small at: i)).
-      self assert: (big at: i)  equals: ((small at: i) max: (big   at: i)) ]
+      self assert: (big at: i)  equals: ((small at: i) max: (big   at: i)) ].
+
+    big   := #( 922337203685477580700
+                922337203685477580700
+               -922337203685477580700
+                922337203685477580700).
+    small := #( 922337203685477529600
+                                    1
+               -922337203685477580701
+               -922337203685477580701).
+
+    big doIndexes: [:i |
+      self optional: #toBeSpecified
+          assert: (big at: i)  equals: ((big   at: i) max: (small at: i)).
+      self optional: #toBeSpecified
+          assert: (big at: i)  equals: ((small at: i) max: (big   at: i)) ].
   )
 )

--- a/TestSuite/SymbolTest.som
+++ b/TestSuite/SymbolTest.som
@@ -38,17 +38,17 @@ SymbolTest = TestCase (
   )
 
   testEquality = (
-    self assert: #oink == #oink.
-    self assert: #oink == 'oink' asSymbol.
-    self assert: #oink =  #oink.
-    self assert: #oink =  'oink' asSymbol.
+    self assert: #oink is: #oink.
+    self assert: #oink is: 'oink' asSymbol.
+    self assert: #oink equals: #oink.
+    self assert: #oink equals: 'oink' asSymbol.
 
-    self deny: #foo =  #fooo.
-    self deny: #foo == #fooo.
+    self deny: #foo equals: #fooo.
+    self deny: #foo is:     #fooo.
 
-    self assert: #foo = 'foo'.
-    self deny: #foo == 'fooo'.
-    self deny: #foo == #foo asString.
+    self assert: #foo equals: 'foo'.
+    self deny: #foo is: 'fooo'.
+    self deny: #foo is: #foo asString.
   )
 
   testSymbolIsString = (

--- a/TestSuite/TestCase.som
+++ b/TestSuite/TestCase.som
@@ -63,6 +63,22 @@ TestCase = (
         self assert: aBooleanOrBlock value not description: aString
     )
 
+    deny: expected equals: actual = (
+        "test value equality"
+        self deny: (expected = actual)
+             description: [
+                'Expected ' + expected asString +
+                ' to differ from ' + actual asString + '.' ]
+    )
+
+    deny: expected is: actual = (
+        "test value equality"
+        self deny: (expected == actual)
+             description: [
+                'Expected ' + expected asString +
+                ' to have different identity from ' + actual asString + '.' ]
+    )
+
     optional: aSymbol deny: aBoolean = (
         self optional: aSymbol assert: aBoolean not
     )

--- a/TestSuite/TestCase.som
+++ b/TestSuite/TestCase.som
@@ -21,6 +21,12 @@ TestCase = (
              description: [self comparingStringBetween: expected and: actual]
     )
 
+    assert: expected equals: actual description: aStringOrBlock = (
+        "test value equality"
+        self assert: (expected = actual)
+             description: aStringOrBlock
+    )
+
     assert: expected is: actual = (
         "test reference equality"
         self assert: (expected == actual)


### PR DESCRIPTION
Because of SOM++, the tests that require arbitrary precision integers should be optional.
Not sure yet whether we really want that in the long term, but that's to be spec'ed else where...

Also add a few more #assert:/#deny: methods for completeness, and use them in SymbolTest to get better errors.